### PR TITLE
Go: style changes; fixed vet/staticcheck issues; better pathing

### DIFF
--- a/Go/rsv.go
+++ b/Go/rsv.go
@@ -1,4 +1,4 @@
-/* (C) Stefan John / Stenway / Stenway.com / 2023 */
+﻿/* (C) Stefan John / Stenway / Stenway.com / 2023 */
 
 package main
 


### PR DESCRIPTION
This PR:

* fixes some basic issues as reported by go vet/staticcheck
* adds system-aware pathing (I believe: not on Windows, cannot vet)
* adds constants for the null value, value separator, and row separator
* adds errors that can be reused, and checked against
* made some variable naming/style changes
* changed `byteClassLookup` and `stateTransitionLookup` from slices to fixed-sized arrays; not necessary, but signals that the vars won't be changing size